### PR TITLE
added GeoNames postalCodeLookup & postalCodeCountryInfo

### DIFF
--- a/NGeo.Tests/GeoNames/CodeTests.cs
+++ b/NGeo.Tests/GeoNames/CodeTests.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Runtime.Serialization;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Should;
+
+namespace NGeo.GeoNames
+{
+    [TestClass]
+    public class CodeTests
+    {
+        [TestMethod]
+        public void GeoNames_Code_ShouldBePublic()
+        {
+            var model = new Code();
+
+            model.ShouldNotBeNull();
+        }
+
+        [TestMethod]
+        public void GeoNames_Code_StringProperties_ShouldBeConvertedToNull_WhenEmptyOrWhiteSpace()
+        {
+            var model = new Code
+            {
+                Admin1Name = "   ",
+                Admin2Name = "   ",
+                Admin3Name = "   ",
+            };
+
+            model.ShouldNotBeNull();
+            model.Admin1Name.ShouldBeNull();
+            model.Admin2Name.ShouldBeNull();
+            model.Admin3Name.ShouldBeNull();
+        }
+
+        [TestMethod]
+        public void GeoNames_Code_ShouldOverrideToString()
+        {
+            var model = new Code
+            {
+                Name = "name",
+            };
+
+            model.ShouldNotBeNull();
+            model.ToString().ShouldEqual(model.Name);
+        }
+
+        [TestMethod]
+        public void GeoNames_Code_ShouldHaveDataContractAttribute()
+        {
+            Attribute.IsDefined(typeof(Code), typeof(DataContractAttribute))
+                .ShouldBeTrue();
+        }
+
+        [TestMethod]
+        public void GeoNames_Code_StringProperties_ShouldHaveDataMemberAttributes()
+        {
+            var properties = new Dictionary<string, Expression<Func<Code, string>>>
+            {
+                { "postalcode", p => p.PostalCode },
+                { "placeName", p => p.Name },
+                { "countryCode", p => p.CountryCode },
+                { "adminCode1", p => p.Admin1Code },
+                { "adminName1", p => p.Admin1Name },
+                { "adminCode2", p => p.Admin2Code },
+                { "adminName2", p => p.Admin2Name },
+                { "adminCode3", p => p.Admin3Code },
+                { "adminName3", p => p.Admin3Name },
+            };
+
+            properties.ShouldHaveDataMemberAttributes();
+        }
+
+        [TestMethod]
+        public void GeoNames_Toponym_DoubleProperties_ShouldHaveDataMemberAttributes()
+        {
+            var properties = new Dictionary<string, Expression<Func<Code, double>>>
+            {
+                { "lat", p => p.Latitude },
+                { "lng", p => p.Longitude },
+            };
+
+            properties.ShouldHaveDataMemberAttributes();
+        }
+    }
+}

--- a/NGeo.Tests/GeoNames/CountryTests.cs
+++ b/NGeo.Tests/GeoNames/CountryTests.cs
@@ -72,6 +72,8 @@ namespace NGeo.GeoNames
                 { "areaInSqKm", p => p.AreaInSqKm },
                 { "currencyCode", p => p.CurrencyCode },
                 { "languages", p => p.Languages },
+                { "maxPostalCode", p => p.MaxPostalCode },
+                { "minPostalCode", p => p.MinPostalCode },
             };
 
             properties.ShouldHaveDataMemberAttributes();
@@ -89,11 +91,12 @@ namespace NGeo.GeoNames
         }
 
         [TestMethod]
-        public void GeoNames_Country_IsoNumericCode_ShouldHaveDataMemberAttribute()
+        public void GeoNames_Country_NullableIntProperties_ShouldHaveDataMemberAttribute()
         {
             var properties = new Dictionary<string, Expression<Func<Country, int?>>>
             {
                 { "isoNumeric", p => p.IsoNumericCode },
+                { "numPostalCodes", p => p.NumberOfPostalCodes },
             };
 
             properties.ShouldHaveDataMemberAttributes();

--- a/NGeo.Tests/GeoNames/GeoNamesClientTests.cs
+++ b/NGeo.Tests/GeoNames/GeoNamesClientTests.cs
@@ -39,6 +39,69 @@ namespace NGeo.GeoNames
         }
 
         [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void GeoNames_PostalCodeLookup_ShouldThrowException_WhenArgIsNull()
+        {
+            using (var geoNames = new GeoNamesClient())
+            {
+                geoNames.PostalCodeLookup(null);
+            }
+        }
+
+        [TestMethod]
+        public void GeoNames_PostalCodeLookup_ShouldReturnNull_WithoutUserName()
+        {
+            using (var geoNames = new GeoNamesClient())
+            {
+                var finder = new PostalCodeLookup();
+                var results = geoNames.PostalCodeLookup(finder);
+                results.ShouldBeNull();
+            }
+        }
+
+        [TestMethod]
+        public void GeoNames_PostalCodeLookup_ShouldReturn1Result_ForOrlando()
+        {
+            using (var geoNames = new GeoNamesClient())
+            {
+                var finder = new PostalCodeLookup
+                {
+                    PostalCode = "32819",
+                    Country = "US",
+                    UserName = UserName,
+                };
+                var results = geoNames.PostalCodeLookup(finder);
+
+                results.ShouldNotBeNull();
+                results.Count.ShouldEqual(1);
+                results[0].Latitude.ShouldEqual(28.452157);
+                results[0].Longitude.ShouldEqual(-81.46784);
+                results[0].Name.ShouldEqual("Orlando");
+            }
+        }
+
+        [TestMethod]
+        public void GeoNames_PostalCodeCountryInfo_ShouldReturnMultipleResults()
+        {
+            using (var geoNames = new GeoNamesClient())
+            {
+                var results = geoNames.PostalCodeCountryInfo(UserName);
+                results.ShouldNotBeNull();
+                results.Count.ShouldBeInRange(2, int.MaxValue);
+            }
+        }
+
+        [TestMethod]
+        public void GeoNames_PostalCodeCountryInfo_ShouldReturnNull_WithoutUserName()
+        {
+            using (var geoNames = new GeoNamesClient())
+            {
+                var results = geoNames.PostalCodeCountryInfo(null);
+                results.ShouldBeNull();
+            }
+        }
+
+        [TestMethod]
         public void GeoNames_FindNearbyPlaceName_ShouldReturn1Result_ForLehighLatitudeAndLongitude_WhenNoRadiusIsSpecified()
         {
             using (var geoNames = new GeoNamesClient())

--- a/NGeo.Tests/GeoNames/IConsumeGeoNamesTests.cs
+++ b/NGeo.Tests/GeoNames/IConsumeGeoNamesTests.cs
@@ -28,6 +28,26 @@ namespace NGeo.GeoNames
         }
 
         [TestMethod]
+        public void GeoNames_PostalCodeLookup_ShouldBeInterfaceMethod()
+        {
+            var contract = new Mock<IConsumeGeoNames>();
+            contract.Setup(m => m.PostalCodeLookup(It.IsAny<PostalCodeLookup>()))
+                .Returns(new ReadOnlyCollection<Code>(new List<Code>()));
+            var results = contract.Object.PostalCodeLookup(null);
+            results.ShouldNotBeNull();
+        }
+
+        [TestMethod]
+        public void GeoNames_PostalCodeCountryInfo_ShouldBeInterfaceMethod()
+        {
+            var contract = new Mock<IConsumeGeoNames>();
+            contract.Setup(m => m.PostalCodeCountryInfo(It.IsAny<string>()))
+                .Returns(new ReadOnlyCollection<Country>(new List<Country>()));
+            var results = contract.Object.PostalCodeCountryInfo(null);
+            results.ShouldNotBeNull();
+        }
+
+        [TestMethod]
         public void GeoNames_Get_ShouldBeInterfaceMethod()
         {
             var contract = new Mock<IConsumeGeoNames>();

--- a/NGeo.Tests/GeoNames/IInvokeGeoNamesServicesTests.cs
+++ b/NGeo.Tests/GeoNames/IInvokeGeoNamesServicesTests.cs
@@ -35,8 +35,15 @@ namespace NGeo.GeoNames
                 { "getJSON", p => p.Get(default(int), default(string)) },
             };
 
+            var codeResultsOperations = new Dictionary<string, Expression<Func<IInvokeGeoNamesServices, PostalCodeResults>>>
+            {
+                { "postalCodeLookupJSON", p => p.PostalCodeLookup(default(string), default(string), default(int),
+                    default(ResultStyle), default(string)) },
+            };
+
             var countryResultsOperations = new Dictionary<string, Expression<Func<IInvokeGeoNamesServices, Results<Country>>>>
             {
+                { "postalCodeCountryInfoJSON", p => p.PostalCodeCountryInfo(default(string)) },
                 { "countryInfoJSON", p => p.Countries(default(string)) },
             };
 
@@ -47,6 +54,7 @@ namespace NGeo.GeoNames
 
             toponymResultsOperations.ShouldHaveOperationContractAttributes();
             toponymOperations.ShouldHaveOperationContractAttributes();
+            codeResultsOperations.ShouldHaveOperationContractAttributes();
             countryResultsOperations.ShouldHaveOperationContractAttributes();
             hierarchyOperations.ShouldHaveOperationContractAttributes();
         }
@@ -78,6 +86,37 @@ namespace NGeo.GeoNames
             attributes.Length.ShouldEqual(1);
             attributes[0].UriTemplate.ShouldEqual("findNearbyPlaceNameJSON?lat={latitude}&lng={longitude}&lang={language}"
                 + "&maxRows={maximumResults}&style={resultStyle}&username={userName}");
+            attributes[0].RequestFormat.ShouldEqual(WebMessageFormat.Json);
+            attributes[0].ResponseFormat.ShouldEqual(WebMessageFormat.Json);
+            attributes[0].BodyStyle.ShouldEqual(WebMessageBodyStyle.Bare);
+        }
+
+        [TestMethod]
+        public void GeoNames_IInvokeGeoNamesServices_PostalCodeLookup_ShouldHaveWebInvokeAttribute()
+        {
+            Expression<Func<IInvokeGeoNamesServices, PostalCodeResults>> method = p => p.PostalCodeLookup(
+                default(string), default(string), default(int), default(ResultStyle), default(string));
+            var attributes = method.GetAttributes<IInvokeGeoNamesServices, PostalCodeResults, WebInvokeAttribute>();
+
+            attributes.ShouldNotBeNull();
+            attributes.Length.ShouldEqual(1);
+            attributes[0].UriTemplate.ShouldEqual("postalCodeLookupJSON?postalcode={postalcode}&country={country}"
+                + "&maxRows={maximumResults}&style={resultStyle}&username={userName}");
+            attributes[0].RequestFormat.ShouldEqual(WebMessageFormat.Json);
+            attributes[0].ResponseFormat.ShouldEqual(WebMessageFormat.Json);
+            attributes[0].BodyStyle.ShouldEqual(WebMessageBodyStyle.Bare);
+        }
+
+        [TestMethod]
+        public void GeoNames_IInvokeGeoNamesServices_PostalCodeCountryInfo_ShouldHaveWebInvokeAttribute()
+        {
+            Expression<Func<IInvokeGeoNamesServices, Results<Country>>> method = p => p.PostalCodeCountryInfo(
+                default(string));
+            var attributes = method.GetAttributes<IInvokeGeoNamesServices, Results<Country>, WebInvokeAttribute>();
+
+            attributes.ShouldNotBeNull();
+            attributes.Length.ShouldEqual(1);
+            attributes[0].UriTemplate.ShouldEqual("postalCodeCountryInfoJSON?username={userName}");
             attributes[0].RequestFormat.ShouldEqual(WebMessageFormat.Json);
             attributes[0].ResponseFormat.ShouldEqual(WebMessageFormat.Json);
             attributes[0].BodyStyle.ShouldEqual(WebMessageBodyStyle.Bare);

--- a/NGeo.Tests/GeoNames/PostalCodeLookupTests.cs
+++ b/NGeo.Tests/GeoNames/PostalCodeLookupTests.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Should;
+
+namespace NGeo.GeoNames
+{
+    [TestClass]
+    public class PostalCodeLookupTests
+    {
+        [TestMethod]
+        public void GeoNames_PostalCodeLookup_ShouldBePublic()
+        {
+            var finder = new PostalCodeLookup
+            {
+                PostalCode = "32819",
+                Country = "US",
+                UserName = "username",
+                MaxRows = 2,
+                Style = ResultStyle.Medium,
+            };
+
+            finder.ShouldNotBeNull();
+            finder.PostalCode.ShouldEqual("32819");
+            finder.Country.ShouldEqual("US");
+            finder.UserName.ShouldNotBeNull();
+            finder.MaxRows.ShouldEqual(2);
+            finder.Style.ShouldEqual(ResultStyle.Medium);
+        }
+
+        [TestMethod]
+        public void GeoNames_PostalCodeLookup_ShouldHaveDefaultValues()
+        {
+            var finder = new PostalCodeLookup();
+
+            finder.ShouldNotBeNull();
+            finder.PostalCode.ShouldBeNull();
+            finder.Country.ShouldBeNull();
+            finder.UserName.ShouldBeNull();
+            finder.MaxRows.ShouldEqual(100);
+            finder.Style.ShouldEqual(ResultStyle.Medium);
+        }
+    }
+}

--- a/NGeo.Tests/GeoNames/PostalCodeResultsTests.cs
+++ b/NGeo.Tests/GeoNames/PostalCodeResultsTests.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Runtime.Serialization;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Should;
+
+namespace NGeo.GeoNames
+{
+    [TestClass]
+    public class PostalCodeResultsTests
+    {
+        [TestMethod]
+        public void GeoNames_PostalCodeResults_ShouldBePublic()
+        {
+            var model = new PostalCodeResults
+            {
+                Items = new List<Code>
+                {
+                    new Code(), new Code(), new Code(),
+                },
+            };
+
+            model.ShouldNotBeNull();
+            model.Items.ShouldNotBeNull();
+            model.Items.Count.ShouldEqual(3);
+        }
+
+        [TestMethod]
+        public void GeoNames_PostalCodeResults_ShouldImplementGenericIEnumerable()
+        {
+            var model = new PostalCodeResults
+            {
+                Items = new List<Code>
+                {
+                    new Code(), new Code(), new Code(),
+                },
+            };
+
+            model.ShouldImplement(typeof(IEnumerable<Code>));
+            model.GetEnumerator().ShouldNotBeNull();
+            ((IEnumerable)model).GetEnumerator().ShouldNotBeNull();
+            foreach (var item in model)
+            {
+                item.ShouldNotBeNull();
+            }
+        }
+
+        [TestMethod]
+        public void GeoNames_PostalCodeResults_ShouldHaveDataContractAttribute()
+        {
+            Attribute.IsDefined(typeof(PostalCodeResults), typeof(DataContractAttribute))
+                .ShouldBeTrue();
+        }
+
+        [TestMethod]
+        public void GeoNames_PostalCodeResults_Items_ShouldHaveDataMemberAttribute()
+        {
+            var genericListProperties = new Dictionary<string, Expression<Func<PostalCodeResults, List<Code>>>>
+            {
+                { "postalcodes", p => p.Items },
+            };
+
+            genericListProperties.ShouldHaveDataMemberAttributes();
+        }
+
+    }
+}

--- a/NGeo.Tests/NGeo.Tests.csproj
+++ b/NGeo.Tests/NGeo.Tests.csproj
@@ -76,6 +76,9 @@
     <Compile Include="ExtensionMethods.cs" />
     <Compile Include="ExtensionMethodTests.cs" />
     <Compile Include="GeoNames\AlternateNameTests.cs" />
+    <Compile Include="GeoNames\CodeTests.cs" />
+    <Compile Include="GeoNames\PostalCodeResultsTests.cs" />
+    <Compile Include="GeoNames\PostalCodeLookupTests.cs" />
     <Compile Include="GeoNames\CountryTests.cs" />
     <Compile Include="GeoNames\GeoNamesClientTests.cs" />
     <Compile Include="GeoNames\ResultsTests.cs" />

--- a/NGeo/GeoNames/Code.cs
+++ b/NGeo/GeoNames/Code.cs
@@ -1,0 +1,61 @@
+﻿using System.Runtime.Serialization;
+
+namespace NGeo.GeoNames
+{
+    [DataContract]
+    public class Code
+    {
+        [DataMember(Name = "postalcode")]
+        public string PostalCode { get; internal set; }
+
+        [DataMember(Name = "placeName")]
+        public string Name { get; internal set; }
+
+        [DataMember(Name = "countryCode")]
+        public string CountryCode { get; internal set; }
+
+        [DataMember(Name = "lat")]
+        public double Latitude { get; internal set; }
+
+        [DataMember(Name = "lng")]
+        public double Longitude { get; internal set; }
+
+        [DataMember(Name = "adminCode1")]
+        public string Admin1Code { get; internal set; }
+
+        [DataMember(Name = "adminName1")]
+        public string Admin1Name
+        {
+            get { return _admin1Name; }
+            internal set { _admin1Name = value.ToNullIfEmptyOrWhiteSpace(); }
+        }
+        private string _admin1Name;
+
+        [DataMember(Name = "adminCode2")]
+        public string Admin2Code { get; internal set; }
+
+        [DataMember(Name = "adminName2")]
+        public string Admin2Name
+        {
+            get { return _admin2Name; }
+            internal set { _admin2Name = value.ToNullIfEmptyOrWhiteSpace(); }
+        }
+        private string _admin2Name;
+
+        [DataMember(Name = "adminCode3")]
+        public string Admin3Code { get; set; }
+
+        [DataMember(Name = "adminName3")]
+        public string Admin3Name
+        {
+            get { return _admin3Name; }
+            internal set { _admin3Name = value.ToNullIfEmptyOrWhiteSpace(); }
+        }
+        private string _admin3Name;
+
+        public override string ToString()
+        {
+            return Name;
+        }
+    }
+}

--- a/NGeo/GeoNames/Country.cs
+++ b/NGeo/GeoNames/Country.cs
@@ -82,6 +82,15 @@ namespace NGeo.GeoNames
         [DataMember(Name = "bBoxSouth")]
         public double? BoundingBoxSouth { get; internal set; }
 
+        [DataMember(Name = "numPostalCodes")]
+        public int? NumberOfPostalCodes { get; internal set; }
+
+        [DataMember(Name = "maxPostalCode")]
+        public string MaxPostalCode { get; internal set; }
+
+        [DataMember(Name = "minPostalCode")]
+        public string MinPostalCode { get; internal set; }
+
         public override string ToString()
         {
             return CountryName;

--- a/NGeo/GeoNames/GeoNamesClient.cs
+++ b/NGeo/GeoNames/GeoNamesClient.cs
@@ -41,6 +41,38 @@ namespace NGeo.GeoNames
         }
 
         /// <summary>
+        /// Lookup a place by postal code. See 
+        /// <seealso cref="http://www.geonames.org/export/web-services.html#postalCodeLookupJSON">Official 
+        /// GeoNames postalCodeLookup Documentation</seealso> for more information.
+        /// </summary>
+        /// <param name="lookup">Arguments sent to the GeoNames service.</param>
+        /// <returns>The closest populated place for the postal code/country query. The unit of the 
+        /// distance element is 'km'.</returns>
+        public ReadOnlyCollection<Code> PostalCodeLookup(PostalCodeLookup lookup)
+        {
+            if (lookup == null) throw new ArgumentNullException("lookup");
+
+            var response = Channel.PostalCodeLookup(lookup.PostalCode, lookup.Country,
+                    lookup.MaxRows, lookup.Style, lookup.UserName);
+            var results = response.Items;
+            return results != null ? new ReadOnlyCollection<Code>(results) : null;
+        }
+
+        /// <summary>
+        /// Postal Code Country Info (countries available with min & max postal codes). See 
+        /// <seealso cref="http://www.geonames.org/export/web-services.html#postalCodeCountryInfo">Official 
+        /// GeoNames postalCodeCountryInfo Documentation</seealso> for more information.
+        /// </summary>
+        /// <param name="userName">Your user name.</param>
+        /// <returns>Country information: Name, Abbreviation, Min & Max Postal Codes.</returns>
+        public ReadOnlyCollection<Country> PostalCodeCountryInfo(string userName)
+        {
+            var response = Channel.PostalCodeCountryInfo(userName);
+            var results = response.Items;
+            return (response.Items != null) ? results.AsReadOnly() : null;
+        }
+
+        /// <summary>
         /// Information about a specific GeoNames toponym, by ID.
         /// </summary>
         /// <param name="geoNameId">The GeoName ID of the toponym to get.</param>

--- a/NGeo/GeoNames/GeoPlanetContainer.cs
+++ b/NGeo/GeoNames/GeoPlanetContainer.cs
@@ -24,6 +24,17 @@ namespace NGeo.GeoNames
             return _client.FindNearbyPlaceName(finder);
         }
 
+        public ReadOnlyCollection<Code> PostalCodeLookup(PostalCodeLookup lookup)
+        {
+            lookup.UserName = _userName;
+            return _client.PostalCodeLookup(lookup);
+        }
+
+        public ReadOnlyCollection<Country> PostalCodeCountryInfo()
+        {
+            return _client.PostalCodeCountryInfo(_userName);
+        }
+
         public Toponym Get(int geoNameId)
         {
             return _client.Get(geoNameId, _userName);

--- a/NGeo/GeoNames/IConsumeGeoNames.cs
+++ b/NGeo/GeoNames/IConsumeGeoNames.cs
@@ -7,6 +7,10 @@ namespace NGeo.GeoNames
     {
         ReadOnlyCollection<Toponym> FindNearbyPlaceName(NearbyPlaceNameFinder finder);
 
+        ReadOnlyCollection<Code> PostalCodeLookup(PostalCodeLookup lookup);
+
+        ReadOnlyCollection<Country> PostalCodeCountryInfo(string userName);
+
         Toponym Get(int geoNameId, string userName);
 
         ReadOnlyCollection<Toponym> Children(int geoNameId, string userName, 

--- a/NGeo/GeoNames/IContainGeoNames.cs
+++ b/NGeo/GeoNames/IContainGeoNames.cs
@@ -7,6 +7,10 @@ namespace NGeo.GeoNames
     {
         ReadOnlyCollection<Toponym> FindNearbyPlaceName(NearbyPlaceNameFinder finder);
 
+        ReadOnlyCollection<Code> PostalCodeLookup(PostalCodeLookup lookup);
+
+        ReadOnlyCollection<Country> PostalCodeCountryInfo();
+
         Toponym Get(int geoNameId);
 
         ReadOnlyCollection<Toponym> Children(int geoNameId,

--- a/NGeo/GeoNames/IInvokeGeoNamesServices.cs
+++ b/NGeo/GeoNames/IInvokeGeoNamesServices.cs
@@ -28,6 +28,26 @@ namespace NGeo.GeoNames
         Results<Toponym> FindNearbyPlaceName(double latitude, double longitude, string language,
             int maximumResults, ResultStyle resultStyle, string userName);
 
+        [OperationContract(Name = "postalCodeLookupJSON")]
+        [WebInvoke(
+            UriTemplate = "postalCodeLookupJSON?postalcode={postalcode}&country={country}"
+                + "&maxRows={maximumResults}&style={resultStyle}&username={userName}",
+            RequestFormat = WebMessageFormat.Json,
+            ResponseFormat = WebMessageFormat.Json,
+            BodyStyle = WebMessageBodyStyle.Bare
+        )]
+        PostalCodeResults PostalCodeLookup(string postalcode, string country, int maximumResults,
+            ResultStyle resultStyle, string userName);
+
+        [OperationContract(Name = "postalCodeCountryInfoJSON")]
+        [WebInvoke(
+            UriTemplate = "postalCodeCountryInfoJSON?username={userName}",
+            RequestFormat = WebMessageFormat.Json,
+            ResponseFormat = WebMessageFormat.Json,
+            BodyStyle = WebMessageBodyStyle.Bare
+        )]
+        Results<Country> PostalCodeCountryInfo(string userName);
+
         [OperationContract(Name = "getJSON")]
         [WebInvoke(
             UriTemplate = "getJSON?geonameId={geoNameId}&username={userName}",

--- a/NGeo/GeoNames/PostalCodeLookup.cs
+++ b/NGeo/GeoNames/PostalCodeLookup.cs
@@ -1,0 +1,43 @@
+﻿
+namespace NGeo.GeoNames
+{
+    /// <summary>
+    /// Encapsulates arguments sent to the PostalCodeLookup service.
+    /// </summary>
+    public class PostalCodeLookup
+    {
+        /// <summary>
+        /// Default property values are: MaxResults = 100, Style = ResultStyle.Full.
+        /// </summary>
+        public PostalCodeLookup()
+        {
+            MaxRows = 100;
+            Style = ResultStyle.Medium;
+        }
+
+        /// <summary>
+        /// Find place names in this postal code.
+        /// </summary>
+        public string PostalCode { get; set; }
+
+        /// <summary>
+        /// Find place names in this country.
+        /// </summary>
+        public string Country { get; set; }
+
+        /// <summary>
+        /// GeoNames services require a user name.
+        /// </summary>
+        public string UserName { get; set; }
+
+        /// <summary>
+        /// Don't return any more than this number of results. Default value is 100.
+        /// </summary>
+        public int MaxRows { get; set; }
+
+        /// <summary>
+        /// Amount of detail returned by the GeoNames service. Default value is Full.
+        /// </summary>
+        public ResultStyle Style { get; set; }
+    }
+}

--- a/NGeo/GeoNames/PostalCodeResults.cs
+++ b/NGeo/GeoNames/PostalCodeResults.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+namespace NGeo.GeoNames
+{
+    [DataContract]
+    public sealed class PostalCodeResults : IEnumerable<Code>
+    {
+        [DataMember(Name = "postalcodes")]
+        internal List<Code> Items { get; set; }
+
+        public IEnumerator<Code> GetEnumerator()
+        {
+            return Items.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}

--- a/NGeo/NGeo.csproj
+++ b/NGeo/NGeo.csproj
@@ -60,6 +60,9 @@
   <ItemGroup>
     <Compile Include="ExtensionMethods.cs" />
     <Compile Include="GeoNames\AlternateName.cs" />
+    <Compile Include="GeoNames\Code.cs" />
+    <Compile Include="GeoNames\PostalCodeResults.cs" />
+    <Compile Include="GeoNames\PostalCodeLookup.cs" />
     <Compile Include="GeoNames\GeoPlanetContainer.cs" />
     <Compile Include="GeoNames\IContainGeoNames.cs" />
     <Compile Include="GeoNames\Country.cs" />


### PR DESCRIPTION
Added the functionality mentioned int he subject, because that's the functionality we need to use.  I also tried to maintain the same coding style & included appropriate unit tests, based on the tests that were already there. I'm open to any feedback you might have.

We're implementing GeoNames at http://www.golfchannel.com/ to replace another less-robust API in our change location function, we're not using any of the Yahoo! APIs.  To see it in action, go to the Golf Channel home page, scroll down to the weather block, and click the city name just above.  Currently accepts US & Canadian zip codes.  GeoNames/NGeo goes live Tuesday July 24 (tomorrow) to replace the existing broken functionality.  The 1st guess at location is coming from the Akamai header, not GeoNames/NGeo.  The block to the left of the weather, where we show an available tee time, takes lat/long, so in our case it's zip code in, lat/long & city name out.
