### PR TITLE
 Yahoo PlaceFinder response-encoding changed to UTF8

### DIFF
--- a/NGeo/Yahoo/PlaceFinder/OAuthClient.cs
+++ b/NGeo/Yahoo/PlaceFinder/OAuthClient.cs
@@ -15,6 +15,7 @@ namespace NGeo.Yahoo.PlaceFinder
         internal OAuthClient()
         {
             _webClient = new WebClient();
+            _webClient.Encoding = Encoding.UTF8;
         }
 
         /// <summary>


### PR DESCRIPTION
The encoding on the PlaceFinder-responses must be UTF8 to support
special characters like german umlauts.
