### PR TITLE
Added FindNearbyPostalCodes endpoint

### DIFF
--- a/NGeo.Tests/GeoNames/GeoNamesClientTests.cs
+++ b/NGeo.Tests/GeoNames/GeoNamesClientTests.cs
@@ -165,6 +165,67 @@ namespace NGeo.GeoNames
         }
 
         [TestMethod]
+        public void GeoNames_FindNearbyPostalCodes_ShouldReturn1Result_ForMollysLatitudeAndLongitude_WhenNoRadiusIsSpecified()
+        {
+            using (var geoNames = new GeoNamesClient())
+            {
+                var finder = new NearbyPostalCodesFinder
+                {
+                    Latitude = 40.611271,
+                    Longitude = -75.378110,
+                    UserName = UserName,
+                };
+                var results = geoNames.FindNearbyPostalCodes(finder);
+
+                results.ShouldNotBeNull();
+                results.Count.ShouldEqual(1);
+                results[0].Value.ShouldEqual("18015");
+            }
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void GeoNames_FindNearbyPostalCodes_ShouldThrowException_WhenArgIsNull()
+        {
+            using (var geoNames = new GeoNamesClient())
+            {
+                geoNames.FindNearbyPostalCodes(null);
+            }
+        }
+
+        [TestMethod]
+        public void GeoNames_FindNearbyPostalCodes_ShouldReturn10Results_ForMollysLatitudeAndLongitude_When10KmRadiusIsSpecified()
+        {
+            using (var geoNames = new GeoNamesClient())
+            {
+                var finder = new NearbyPostalCodesFinder
+                {
+                    Latitude = 40.611271,
+                    Longitude = -75.378110,
+                    UserName = UserName,
+                    RadiusInKm = 10.0,
+                    MaxRows = 10,
+                };
+                var results = geoNames.FindNearbyPostalCodes(finder);
+
+                results.ShouldNotBeNull();
+                results.Count.ShouldEqual(10);
+                results[0].Value.ShouldEqual("18015");
+            }
+        }
+
+        [TestMethod]
+        public void GeoNames_FindNearbyPostalCodes_ShouldReturnNull_WithoutUserName()
+        {
+            using (var geoNames = new GeoNamesClient())
+            {
+                var finder = new NearbyPostalCodesFinder();
+                var results = geoNames.FindNearbyPostalCodes(finder);
+                results.ShouldBeNull();
+            }
+        }
+
+        [TestMethod]
         public void GeoNames_Get_ShouldReturn1EarthResult_ForGeoNameId6295630()
         {
             using (var geoNames = new GeoNamesClient())

--- a/NGeo.Tests/GeoNames/GeoNamesContainerTests.cs
+++ b/NGeo.Tests/GeoNames/GeoNamesContainerTests.cs
@@ -150,6 +150,65 @@ namespace NGeo.GeoNames
                 results.ShouldBeNull();
             }
         }
+        
+        [TestMethod]
+        public void GeoNames_FindNearbyPostalCodes_ShouldReturn1Result_ForMollysLatitudeAndLongitude_WhenNoRadiusIsSpecified()
+        {
+            using (var geoNames = new GeoNamesContainer(UserName))
+            {
+                var finder = new NearbyPostalCodesFinder
+                {
+                    Latitude = 40.611271,
+                    Longitude = -75.378110,
+                };
+                var results = geoNames.FindNearbyPostalCodes(finder);
+
+                results.ShouldNotBeNull();
+                results.Count.ShouldEqual(1);
+                results[0].Value.ShouldEqual("18015");
+            }
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void GeoNames_FindNearbyPostalCodes_ShouldThrowException_WhenArgIsNull()
+        {
+            using (var geoNames = new GeoNamesContainer(null))
+            {
+                geoNames.FindNearbyPostalCodes(null);
+            }
+        }
+
+        [TestMethod]
+        public void GeoNames_FindNearbyPostalCodes_ShouldReturn10Results_ForMollysLatitudeAndLongitude_When10KmRadiusIsSpecified()
+        {
+            using (var geoNames = new GeoNamesContainer(UserName))
+            {
+                var finder = new NearbyPostalCodesFinder
+                {
+                    Latitude = 40.611271,
+                    Longitude = -75.378110,
+                    RadiusInKm = 10.0,
+                    MaxRows = 10,
+                };
+                var results = geoNames.FindNearbyPostalCodes(finder);
+
+                results.ShouldNotBeNull();
+                results.Count.ShouldEqual(10);
+                results[0].Value.ShouldEqual("18015");
+            }
+        }
+
+        [TestMethod]
+        public void GeoNames_FindNearbyPostalCodes_ShouldReturnNull_WithoutUserName()
+        {
+            using (var geoNames = new GeoNamesContainer(null))
+            {
+                var finder = new NearbyPostalCodesFinder();
+                var results = geoNames.FindNearbyPostalCodes(finder);
+                results.ShouldBeNull();
+            }
+        }
 
         [TestMethod]
         public void GeoNames_Get_ShouldReturn1EarthResult_ForGeoNameId6295630()

--- a/NGeo.Tests/GeoNames/IConsumeGeoNamesTests.cs
+++ b/NGeo.Tests/GeoNames/IConsumeGeoNamesTests.cs
@@ -38,6 +38,16 @@ namespace NGeo.GeoNames
         }
 
         [TestMethod]
+        public void GeoNames_FindNearbyPostalCodes_ShouldBeInterfaceMethod()
+        {
+            var contract = new Mock<IConsumeGeoNames>();
+            contract.Setup(m => m.FindNearbyPostalCodes(It.IsAny<NearbyPostalCodesFinder>()))
+                .Returns(new ReadOnlyCollection<NearbyPostalCode>(new List<NearbyPostalCode>()));
+            var results = contract.Object.FindNearbyPostalCodes(null);
+            results.ShouldNotBeNull();
+        }
+
+        [TestMethod]
         public void GeoNames_PostalCodeCountryInfo_ShouldBeInterfaceMethod()
         {
             var contract = new Mock<IConsumeGeoNames>();

--- a/NGeo.Tests/GeoNames/IContainGeoNamesTests.cs
+++ b/NGeo.Tests/GeoNames/IContainGeoNamesTests.cs
@@ -38,6 +38,16 @@ namespace NGeo.GeoNames
         }
 
         [TestMethod]
+        public void GeoNames_FindNearbyPostalCodes_ShouldBeInterfaceMethod()
+        {
+            var contract = new Mock<IContainGeoNames>();
+            contract.Setup(m => m.FindNearbyPostalCodes(It.IsAny<NearbyPostalCodesFinder>()))
+                .Returns(new ReadOnlyCollection<NearbyPostalCode>(new List<NearbyPostalCode>()));
+            var results = contract.Object.FindNearbyPostalCodes(null);
+            results.ShouldNotBeNull();
+        }
+
+        [TestMethod]
         public void GeoNames_PostalCodeCountryInfo_ShouldBeInterfaceMethod()
         {
             var contract = new Mock<IContainGeoNames>();

--- a/NGeo.Tests/GeoNames/IInvokeGeoNamesServicesTests.cs
+++ b/NGeo.Tests/GeoNames/IInvokeGeoNamesServicesTests.cs
@@ -41,6 +41,15 @@ namespace NGeo.GeoNames
                     default(ResultStyle), default(string)) },
             };
 
+            var NearbyPostalCodeResultsOperations = new Dictionary<string, Expression<Func<IInvokeGeoNamesServices, NearbyPostalCodeResults>>>
+            {
+                { "findNearbyPostalCodesJSON0", p => p.FindNearbyPostalCodes(default(double), default(double), default(double),
+                    default(string), default(string), 
+                    default(int), default(ResultStyle), default(string)) },
+                { "findNearbyPostalCodesJSON1", p => p.FindNearbyPostalCodes(default(string), default(string), default(double), 
+                    default(int), default(ResultStyle), default(string)) },
+            };
+
             var countryResultsOperations = new Dictionary<string, Expression<Func<IInvokeGeoNamesServices, Results<Country>>>>
             {
                 { "countryInfoJSON", p => p.Countries(default(string)) },
@@ -106,6 +115,42 @@ namespace NGeo.GeoNames
             attributes.ShouldNotBeNull();
             attributes.Length.ShouldEqual(1);
             attributes[0].UriTemplate.ShouldEqual("postalCodeLookupJSON?postalcode={postalcode}&country={country}"
+                + "&maxRows={maximumResults}&style={resultStyle}&username={userName}");
+            attributes[0].RequestFormat.ShouldEqual(WebMessageFormat.Json);
+            attributes[0].ResponseFormat.ShouldEqual(WebMessageFormat.Json);
+            attributes[0].BodyStyle.ShouldEqual(WebMessageBodyStyle.Bare);
+        }
+
+        [TestMethod]
+        public void GeoNames_IInvokeGeoNamesServices_FindNearbyPostalCodes_WithPostalCodeParameter_ShouldHaveWebInvokeAttribute()
+        {
+            Expression<Func<IInvokeGeoNamesServices, NearbyPostalCodeResults>> method = p =>
+                p.FindNearbyPostalCodes(default(string), default(string), default(double),
+                default(int), default(ResultStyle), default(string));
+            var attributes = method.GetAttributes<IInvokeGeoNamesServices, NearbyPostalCodeResults, WebInvokeAttribute>();
+
+            attributes.ShouldNotBeNull();
+            attributes.Length.ShouldEqual(1);
+            attributes[0].UriTemplate.ShouldEqual("findNearbyPostalCodesJSON?postalcode={postalCode}&country={country}&radius={radiusInKm}"
+                + "&maxRows={maximumResults}&style={resultStyle}&username={userName}");
+            attributes[0].RequestFormat.ShouldEqual(WebMessageFormat.Json);
+            attributes[0].ResponseFormat.ShouldEqual(WebMessageFormat.Json);
+            attributes[0].BodyStyle.ShouldEqual(WebMessageBodyStyle.Bare);
+        }
+
+        [TestMethod]
+        public void GeoNames_IInvokeGeoNamesServices_FindNearbyPostalCodes_WithoutPostalCodeParameter_ShouldHaveWebInvokeAttribute()
+        {
+            Expression<Func<IInvokeGeoNamesServices, NearbyPostalCodeResults>> method = p =>
+                p.FindNearbyPostalCodes(default(double), default(double), default(double),
+                default(string), default(string), 
+                default(int), default(ResultStyle), default(string));
+            var attributes = method.GetAttributes<IInvokeGeoNamesServices, NearbyPostalCodeResults, WebInvokeAttribute>();
+
+            attributes.ShouldNotBeNull();
+            attributes.Length.ShouldEqual(1);
+            attributes[0].UriTemplate.ShouldEqual("findNearbyPostalCodesJSON?lat={latitude}&lng={longitude}&radius={radiusInKm}"
+                + "&country={country}&localcountry={localCountry}"
                 + "&maxRows={maximumResults}&style={resultStyle}&username={userName}");
             attributes[0].RequestFormat.ShouldEqual(WebMessageFormat.Json);
             attributes[0].ResponseFormat.ShouldEqual(WebMessageFormat.Json);

--- a/NGeo/GeoNames/GeoNamesContainer.cs
+++ b/NGeo/GeoNames/GeoNamesContainer.cs
@@ -30,6 +30,12 @@ namespace NGeo.GeoNames
             return _client.LookupPostalCode(lookup);
         }
 
+        public ReadOnlyCollection<NearbyPostalCode> FindNearbyPostalCodes(NearbyPostalCodesFinder finder)
+        {
+            if (finder != null) finder.UserName = _userName;
+            return _client.FindNearbyPostalCodes(finder);
+        }
+
         public ReadOnlyCollection<PostalCodedCountry> PostalCodeCountryInfo()
         {
             return _client.PostalCodeCountryInfo(_userName);

--- a/NGeo/GeoNames/IConsumeGeoNames.cs
+++ b/NGeo/GeoNames/IConsumeGeoNames.cs
@@ -9,6 +9,8 @@ namespace NGeo.GeoNames
 
         ReadOnlyCollection<PostalCode> LookupPostalCode(PostalCodeLookup lookup);
 
+        ReadOnlyCollection<NearbyPostalCode> FindNearbyPostalCodes(NearbyPostalCodesFinder finder);
+
         ReadOnlyCollection<PostalCodedCountry> PostalCodeCountryInfo(string userName);
 
         Toponym Get(int geoNameId, string userName);

--- a/NGeo/GeoNames/IContainGeoNames.cs
+++ b/NGeo/GeoNames/IContainGeoNames.cs
@@ -9,6 +9,8 @@ namespace NGeo.GeoNames
 
         ReadOnlyCollection<PostalCode> LookupPostalCode(PostalCodeLookup lookup);
 
+        ReadOnlyCollection<NearbyPostalCode> FindNearbyPostalCodes(NearbyPostalCodesFinder finder);
+
         ReadOnlyCollection<PostalCodedCountry> PostalCodeCountryInfo();
 
         Toponym Get(int geoNameId);

--- a/NGeo/GeoNames/IInvokeGeoNamesServices.cs
+++ b/NGeo/GeoNames/IInvokeGeoNamesServices.cs
@@ -39,6 +39,30 @@ namespace NGeo.GeoNames
         PostalCodeResults LookupPostalCode(string postalcode, string country, int maximumResults,
             ResultStyle resultStyle, string userName);
 
+        [OperationContract(Name = "findNearbyPostalCodesJSON0")]
+        [WebInvoke(
+            UriTemplate = "findNearbyPostalCodesJSON?lat={latitude}&lng={longitude}&radius={radiusInKm}"
+                + "&country={country}&localcountry={localCountry}"
+                + "&maxRows={maximumResults}&style={resultStyle}&username={userName}",
+            RequestFormat = WebMessageFormat.Json,
+            ResponseFormat = WebMessageFormat.Json,
+            BodyStyle = WebMessageBodyStyle.Bare
+        )]
+        NearbyPostalCodeResults FindNearbyPostalCodes(double latitude, double longitude, double radiusInKm, 
+            string country, string localCountry,
+            int maximumResults, ResultStyle resultStyle, string userName);
+
+        [OperationContract(Name = "findNearbyPostalCodesJSON1")]
+        [WebInvoke(
+            UriTemplate = "findNearbyPostalCodesJSON?postalcode={postalCode}&country={country}&radius={radiusInKm}"
+                + "&maxRows={maximumResults}&style={resultStyle}&username={userName}",
+            RequestFormat = WebMessageFormat.Json,
+            ResponseFormat = WebMessageFormat.Json,
+            BodyStyle = WebMessageBodyStyle.Bare
+        )]
+        NearbyPostalCodeResults FindNearbyPostalCodes(string postalCode, string country, double radiusInKm, 
+            int maximumResults, ResultStyle resultStyle, string userName);
+
         [OperationContract(Name = "postalCodeCountryInfoJSON")]
         [WebInvoke(
             UriTemplate = "postalCodeCountryInfoJSON?username={userName}",

--- a/NGeo/GeoNames/NearbyPostalCode.cs
+++ b/NGeo/GeoNames/NearbyPostalCode.cs
@@ -1,0 +1,64 @@
+﻿using System.Runtime.Serialization;
+
+namespace NGeo.GeoNames
+{
+    [DataContract]
+    public class NearbyPostalCode
+    {
+        [DataMember(Name = "postalCode")]
+        public string Value { get; internal set; }
+
+        [DataMember(Name = "placeName")]
+        public string Name { get; internal set; }
+
+        [DataMember(Name = "countryCode")]
+        public string CountryCode { get; internal set; }
+
+        [DataMember(Name = "lat")]
+        public double Latitude { get; internal set; }
+
+        [DataMember(Name = "lng")]
+        public double Longitude { get; internal set; }
+
+        [DataMember(Name = "distance")]
+        public double Distance { get; set; }
+
+        [DataMember(Name = "adminCode1")]
+        public string Admin1Code { get; internal set; }
+
+        [DataMember(Name = "adminName1")]
+        public string Admin1Name
+        {
+            get { return _admin1Name; }
+            internal set { _admin1Name = value.ToNullIfEmptyOrWhiteSpace(); }
+        }
+        private string _admin1Name;
+
+        [DataMember(Name = "adminCode2")]
+        public string Admin2Code { get; internal set; }
+
+        [DataMember(Name = "adminName2")]
+        public string Admin2Name
+        {
+            get { return _admin2Name; }
+            internal set { _admin2Name = value.ToNullIfEmptyOrWhiteSpace(); }
+        }
+        private string _admin2Name;
+
+        [DataMember(Name = "adminCode3")]
+        public string Admin3Code { get; set; }
+
+        [DataMember(Name = "adminName3")]
+        public string Admin3Name
+        {
+            get { return _admin3Name; }
+            internal set { _admin3Name = value.ToNullIfEmptyOrWhiteSpace(); }
+        }
+        private string _admin3Name;
+
+        public override string ToString()
+        {
+            return Name;
+        }
+    }
+}

--- a/NGeo/GeoNames/NearbyPostalCodeResults.cs
+++ b/NGeo/GeoNames/NearbyPostalCodeResults.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+namespace NGeo.GeoNames
+{
+    [DataContract]
+    public sealed class NearbyPostalCodeResults : IEnumerable<NearbyPostalCode>
+    {
+        [DataMember(Name = "postalCodes")]
+        internal List<NearbyPostalCode> Items { get; set; }
+
+        public IEnumerator<NearbyPostalCode> GetEnumerator()
+        {
+            return Items.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}

--- a/NGeo/GeoNames/NearbyPostalCodesFinder.cs
+++ b/NGeo/GeoNames/NearbyPostalCodesFinder.cs
@@ -1,0 +1,77 @@
+﻿
+namespace NGeo.GeoNames
+{
+    /// <summary>
+    /// Encapsulates arguments sent to the FindNearbyPostalCodes service.
+    /// There are two variants:
+    /// 1. Lat/Lon - Returns postal codes nearby this point.
+    /// 2. Postal Code/Country - Returns postal codes nearby this postal code.
+    /// </summary>
+    public class NearbyPostalCodesFinder
+    {
+        /// <summary>
+        /// Default property values are: Language = "local", MaxRows = 100, Style = ResultStyle.Medium.
+        /// </summary>
+        public NearbyPostalCodesFinder()
+        {
+            Language = "local";
+            MaxRows = 100;
+            Style = ResultStyle.Medium;
+        }
+
+        /// <summary>
+        /// Find postal codes near this latitude.
+        /// </summary>
+        public double Latitude { get; set; }
+
+        /// <summary>
+        /// Find postal codes near this longitude.
+        /// </summary>
+        public double Longitude { get; set; }
+
+        /// <summary>
+        /// GeoNames services require a user name.
+        /// </summary>
+        public string UserName { get; set; }
+
+        /// <summary>
+        /// Find postal codes near this postal code.
+        /// </summary>
+        public string PostalCode { get; set; }
+
+        /// <summary>
+        /// Country for the postal code parameter when the postal code/country/radius 
+        /// variant is used.
+        /// </summary>
+        public string Country { get; set; }
+
+        /// <summary>
+        /// In border areas this parameter will restrict the search on the local 
+        /// country.
+        /// </summary>
+        public string LocalCountry { get; set; }
+
+        /// <summary>
+        /// Find postal codes within this radius of the latitude and longitude.
+        /// Note: The Local Country parameter is not (yet) supported.
+        /// </summary>
+        public double RadiusInKm { get; set; }
+
+        /// <summary>
+        /// Language of returned 'name' element (the pseudo language code 'local' will 
+        /// return it in local language).
+        /// Default value is 'local'.
+        /// </summary>
+        public string Language { get; set; }
+
+        /// <summary>
+        /// Don't return any more than this number of results. Default value is 100.
+        /// </summary>
+        public int MaxRows { get; set; }
+
+        /// <summary>
+        /// Amount of detail returned by the GeoNames service. Default value is Full.
+        /// </summary>
+        public ResultStyle Style { get; set; }
+    }
+}

--- a/NGeo/GlobalSuppressions.cs
+++ b/NGeo/GlobalSuppressions.cs
@@ -376,6 +376,10 @@
     Target = "NGeo.GeoNames.NearbyPlaceNameFinder.#RadiusInKm",
     Justification = "Casing matches ReSharper casing rules.")]
 [assembly: SuppressMessage("Microsoft.Naming", "CA1709:IdentifiersShouldBeCasedCorrectly",
+    MessageId = "Km", Scope = "member",
+    Target = "NGeo.GeoNames.NearbyPostalCodeFinder.#RadiusInKm",
+    Justification = "Casing matches ReSharper casing rules.")]
+[assembly: SuppressMessage("Microsoft.Naming", "CA1709:IdentifiersShouldBeCasedCorrectly",
     MessageId = "Sq", Scope = "member",
     Target = "NGeo.GeoNames.Country.#AreaInSqKm",
     Justification = "Casing matches ReSharper casing rules.")]

--- a/NGeo/NGeo.csproj
+++ b/NGeo/NGeo.csproj
@@ -64,8 +64,11 @@
   <ItemGroup>
     <Compile Include="ExtensionMethods.cs" />
     <Compile Include="GeoNames\AlternateName.cs" />
+    <Compile Include="GeoNames\NearbyPostalCodesFinder.cs" />
+    <Compile Include="GeoNames\NearbyPostalCode.cs" />
     <Compile Include="GeoNames\PostalCodedCountry.cs" />
     <Compile Include="GeoNames\PostalCode.cs" />
+    <Compile Include="GeoNames\NearbyPostalCodeResults.cs" />
     <Compile Include="GeoNames\PostalCodeResults.cs" />
     <Compile Include="GeoNames\PostalCodeLookup.cs" />
     <Compile Include="GeoNames\GeoNamesContainer.cs" />


### PR DESCRIPTION
Greetings Dan!

First, nice work on this. It's really quite extensive and I've learned a bunch from it.

Generally I've tried to follow your form to the greatest extent possible, basically copying similar bits and changing names. I would appreciate any feedback on things I may have missed.

I've added the FindNearbyPostalCodes endpoint to allow simple lookup of postal code from lat lon.

Note that the GeoName API uses a capital C in "postalCode" in the JSON response for the FindNearbyPostalCodes message, thus the different NearbyPostalCode and NearbyPostalCodeResults classes that are apart from that and one other thing nearly identical. That other thing is that the nearby postal codes include a distance value. Given those two differences I chose to create separate classes instead of having one inherit from the other.

All existing non-Yahoo unit tests have been run and passed, and new tests have been added for the new endpoint. Yahoo has discontinued their APIs, and all yahoo test cases are thus failing. Since the fix for this is to either add another API or delete all the Yahoo stuff I felt it best left to you.